### PR TITLE
Add equa.cc wind-down runbook + inventory script

### DIFF
--- a/runbooks/WIND_DOWN_EQUA_CC.md
+++ b/runbooks/WIND_DOWN_EQUA_CC.md
@@ -1,0 +1,117 @@
+# Wind Down Public `equa.cc` (Issue #358)
+
+> Non-destructive, rollback-friendly plan to reduce GCP spend.
+
+## What we can confirm from outside (no GCP auth)
+As of **2026-02-21**:
+- `equa.cc` **A** → `136.110.187.76`
+- `api.equa.cc` **A** → `136.110.187.76`
+- Reverse DNS for `136.110.187.76` → `*.bc.googleusercontent.com` (Google Cloud customer IP)
+- `app.equa.cc` **CNAME** → `ghs.googlehosted.com` (Google hosted)
+- Nameservers → `ns-cloud-c*.googledomains.com` (Google Cloud DNS)
+- `curl -I https://equa.cc` returns `server: Google Frontend` (often indicates HTTPS Load Balancer and/or serverless)
+- `curl -I https://api.equa.cc` returns `x-powered-by: Express` + `server: Google Frontend`
+
+**Implication:** there is very likely a **Google Cloud HTTPS Load Balancer** (or similar Google front-door) serving both the static site and the API.
+
+## Immediate goal
+Reduce monthly run-rate to near-idle by:
+1) backing up data + capturing config
+2) cutting public traffic at DNS/edge
+3) scaling compute to zero / stopping VMs
+4) sweeping for lingering billable resources (LB/NAT/static IP/Artifact Registry/SQL)
+
+## Inputs needed from Shawn (to make the checklist exact)
+Please provide one of:
+- the **GCP Project ID** that owns the `equa.cc` infra (and any staging project), or
+- paste the output of `gcloud projects list` and confirm which project is prod.
+
+Also helpful:
+- whether the API is Cloud Run vs GCE VM vs GKE
+- what DB is used (Cloud SQL Postgres/MySQL? Firestore?)
+
+## Inventory commands (copy/paste)
+> These are safe read-only commands.
+
+```bash
+gcloud config get-value project
+
+gcloud run services list --platform=managed --regions=all
+
+gcloud compute instances list
+
+gcloud compute forwarding-rules list --global
+
+gcloud compute url-maps list
+
+gcloud compute target-https-proxies list
+
+gcloud compute backend-services list --global
+
+gcloud compute addresses list --global
+
+gcloud dns managed-zones list
+# If zone is known:
+# gcloud dns record-sets list --zone <zone>
+
+gcloud sql instances list
+
+gcloud scheduler jobs list --locations=all
+
+gcloud pubsub topics list
+
+gcloud pubsub subscriptions list
+
+gcloud storage buckets list
+
+gcloud artifacts repositories list --locations=all
+
+gcloud compute routers list --regions=all
+
+gcloud compute networks subnets list --regions=all
+```
+
+## Backup / capture state (do BEFORE stopping)
+1) **Cloud SQL**: create on-demand backup + export to GCS (portable)
+2) **Firestore** (if used): export to GCS
+3) **GCS buckets**: at least list buckets; optionally rsync critical buckets to a dedicated backup bucket
+4) **Cloud Run**: export service config YAML/JSON (env var names only; do not commit secret values)
+5) **Cloud DNS**: export zone file
+
+## Shutdown sequence (recommended)
+### Step 1 — Cut public traffic (fast rollback)
+Option A (preferred): **DNS cutover**
+- Lower TTL to 60s (temporary)
+- Point `equa.cc` and `api.equa.cc` to a maintenance target (cheap static host)
+- Keep old records for rollback
+
+Option B: **Lock down API**
+- For Cloud Run: remove `allUsers` invoker IAM binding
+
+### Step 2 — Stop/scale compute
+- Cloud Run: set `min-instances=0` (and verify CPU is request-only)
+- Compute Engine: stop VMs
+- GKE: scale node pools to 0 or minimum
+- Pause Cloud Scheduler jobs / disable Pub/Sub push endpoints
+
+### Step 3 — Billing sweep
+Within 24–72 hours, check Billing → Reports SKUs.
+Common lingering costs:
+- Cloud SQL instance tier/storage
+- HTTPS Load Balancer (base hourly + rule)
+- Cloud NAT
+- Reserved static external IPs
+- Artifact Registry storage
+
+## Rollback (keep this trivial)
+- Revert DNS records to previous values
+- Re-enable Cloud Run invoker / restart VMs / restore scheduler jobs
+
+## Cost levers (rule-of-thumb)
+Without the project’s Billing → SKU breakdown, exact numbers aren’t possible, but typical major spend drivers are:
+- **Cloud SQL** (often $100–$400/mo depending tier/HA/storage)
+- **GKE node pools / VMs** (varies widely)
+- **HTTPS Load Balancer** (commonly ~$18+/mo base, plus usage)
+- **Cloud NAT** (can be ~$30+/mo base + data)
+
+Next step is to run the inventory commands above and identify the top 3 SKUs in Billing.

--- a/scripts/gcp_inventory_dump.sh
+++ b/scripts/gcp_inventory_dump.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only inventory dump for equa.cc wind-down.
+# Usage:
+#   ./scripts/gcp_inventory_dump.sh <project-id> [output-dir]
+
+PROJECT_ID="${1:-}"
+OUT_DIR="${2:-}"
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "Usage: $0 <project-id> [output-dir]" >&2
+  exit 1
+fi
+
+TS="$(date +%Y%m%d-%H%M%S)"
+if [[ -z "$OUT_DIR" ]]; then
+  OUT_DIR="$HOME/equa-winddown-inventory/$PROJECT_ID/$TS"
+fi
+
+mkdir -p "$OUT_DIR/state"
+
+echo "Writing inventory to: $OUT_DIR" >&2
+
+gcloud config set project "$PROJECT_ID" >/dev/null
+
+echo "project" >&2
+(gcloud projects describe "$PROJECT_ID" --format=json || true) > "$OUT_DIR/state/project.json"
+
+echo "enabled apis" >&2
+(gcloud services list --enabled --format=json || true) > "$OUT_DIR/state/enabled-apis.json"
+
+echo "cloud run" >&2
+(gcloud run services list --platform=managed --regions=all --format=json || true) > "$OUT_DIR/state/cloudrun-services.json"
+
+echo "compute" >&2
+(gcloud compute instances list --format=json || true) > "$OUT_DIR/state/compute-instances.json"
+
+echo "load balancer bits" >&2
+(gcloud compute forwarding-rules list --global --format=json || true) > "$OUT_DIR/state/lb-forwarding-rules.json"
+(gcloud compute url-maps list --format=json || true) > "$OUT_DIR/state/lb-url-maps.json"
+(gcloud compute target-https-proxies list --format=json || true) > "$OUT_DIR/state/lb-https-proxies.json"
+(gcloud compute backend-services list --global --format=json || true) > "$OUT_DIR/state/lb-backend-services.json"
+(gcloud compute addresses list --global --format=json || true) > "$OUT_DIR/state/compute-addresses-global.json"
+
+(gcloud compute routers list --regions=all --format=json || true) > "$OUT_DIR/state/compute-routers.json"
+(gcloud compute networks list --format=json || true) > "$OUT_DIR/state/networks.json"
+(gcloud compute networks subnets list --regions=all --format=json || true) > "$OUT_DIR/state/subnets.json"
+
+
+echo "dns" >&2
+(gcloud dns managed-zones list --format=json || true) > "$OUT_DIR/state/dns-zones.json"
+
+# If you know the zone, export record sets:
+# ZONE="equa-cc"
+# gcloud dns record-sets export "$OUT_DIR/state/dns-$ZONE.zone" --zone "$ZONE" || true
+
+
+echo "sql" >&2
+(gcloud sql instances list --format=json || true) > "$OUT_DIR/state/cloudsql-instances.json"
+
+
+echo "scheduler" >&2
+(gcloud scheduler jobs list --locations=all --format=json || true) > "$OUT_DIR/state/scheduler-jobs.json"
+
+
+echo "pubsub" >&2
+(gcloud pubsub topics list --format=json || true) > "$OUT_DIR/state/pubsub-topics.json"
+(gcloud pubsub subscriptions list --format=json || true) > "$OUT_DIR/state/pubsub-subscriptions.json"
+
+
+echo "storage" >&2
+(gcloud storage buckets list --format=json || true) > "$OUT_DIR/state/gcs-buckets.json"
+
+
+echo "artifact registry" >&2
+(gcloud artifacts repositories list --locations=all --format=json || true) > "$OUT_DIR/state/artifact-repos.json"
+
+
+echo "done" >&2
+printf "%s\n" "$OUT_DIR" > "$OUT_DIR/OUT_DIR.txt"


### PR DESCRIPTION
Adds a concrete, rollback-friendly wind-down runbook for equa.cc plus a read-only gcloud inventory dump script to quickly identify active resources and cost drivers.\n\nRelated: #358