### PR TITLE
Add equa.cc public recon + cost check checklist

### DIFF
--- a/runbooks/EQUA_CC_COST_CHECK.md
+++ b/runbooks/EQUA_CC_COST_CHECK.md
@@ -1,0 +1,57 @@
+# equa.cc — Cost check (GCP)
+
+This is a lightweight checklist to identify **what is still charging** after you cut traffic and/or stop services.
+
+> Goal: drive run-rate to **<$50/mo** while keeping rollback possible.
+
+## 1) Quick billing snapshot (UI)
+
+1. Open **GCP Console → Billing → Reports**
+2. Set:
+   - **Project** = the equa.cc prod project
+   - **Time range** = last **7 days** (and also last **24 hours** after changes)
+   - **Group by** = **SKU** (and optionally by **Service**)
+3. Export or copy the top 10 SKUs.
+
+### Common “lingering charge” culprits
+- **Cloud SQL** (often the #1 cost driver)
+- **Cloud Load Balancing** (forwarding rules, URL maps, proxies)
+- **Cloud NAT** (if used)
+- **Compute Engine**: instance core hours, persistent disks, snapshots
+- **Artifact Registry** storage
+- **Cloud Logging** ingestion/retention
+- **BigQuery** storage/query
+
+## 2) Programmatic run-rate check (requires gcloud auth)
+
+If you have permission, you can use the Billing export APIs, but the UI is usually faster.
+
+A practical approach is:
+- use `scripts/gcp_inventory_dump.sh <PROJECT_ID>` to list what exists
+- use Billing Reports (UI) to map charges → specific resources
+
+## 3) Fast mapping: resource → cost lever
+
+| Resource | Cost lever | Rollback friendliness |
+|---|---|---|
+| Cloud Run | set min instances = 0; remove unauth invoker; disable schedulers calling it | very high |
+| Cloud SQL | stop instance (if supported) or downsize tier | medium-high (depending on restore) |
+| HTTPS Load Balancer | delete LB components and release static IP **after DNS cutover** | medium |
+| Reserved external IP | release if unused | high |
+| Cloud NAT | delete NAT router if no egress needs remain | medium |
+| Logging | reduce retention / exclusions | high |
+
+## 4) After changes: verify
+
+- Re-check Billing Reports after **24–72h**.
+- Confirm:
+  - No Cloud SQL compute charges (or reduced)
+  - LB / static IP charges reduced
+  - No unexpected VM/GKE charges
+
+## 5) Attach findings back to the issue
+
+When reporting back, paste:
+- project id
+- top SKUs (7d) and (24h)
+- inventory dump folder path created by `gcp_inventory_dump.sh`

--- a/scripts/equa_cc_public_recon.sh
+++ b/scripts/equa_cc_public_recon.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only public reconnaissance for equa.cc.
+# Purpose: identify likely hosting surface (LB vs Cloud Run vs GCE/GKE) *without* GCP credentials.
+# Output: writes a timestamped folder under ./tmp/equa-cc-public-recon/
+
+ROOT_DOMAIN="${1:-equa.cc}"
+API_DOMAIN="${2:-api.equa.cc}"
+APP_DOMAIN="${3:-app.equa.cc}"
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUTDIR="tmp/equa-cc-public-recon/${TS}"
+mkdir -p "${OUTDIR}"
+
+log() { printf "%s\n" "$*" | tee -a "${OUTDIR}/_log.txt" >/dev/null; }
+run() {
+  log "$ $*"
+  # shellcheck disable=SC2068
+  ( $@ ) 2>&1 | tee -a "${OUTDIR}/_log.txt" >"${OUTDIR}/$(echo "$*" | tr ' /' '__' | tr -cd '[:alnum:]_\n\-').txt" || true
+}
+
+log "# equa.cc public recon"
+log "timestamp_utc=${TS}"
+log "root=${ROOT_DOMAIN} api=${API_DOMAIN} app=${APP_DOMAIN}"
+
+# DNS
+run dig +noall +answer "${ROOT_DOMAIN}" A AAAA CNAME
+run dig +noall +answer "${API_DOMAIN}" A AAAA CNAME
+run dig +noall +answer "${APP_DOMAIN}" A AAAA CNAME
+
+# Nameservers for the zone
+run dig +noall +answer "${ROOT_DOMAIN}" NS
+
+# HTTP headers (follow redirects)
+run curl -sS -D - -o /dev/null -L "https://${ROOT_DOMAIN}"
+run curl -sS -D - -o /dev/null -L "https://${API_DOMAIN}"
+
+# TLS certificate chain summary
+# Note: will hang if SNI mismatch; we pass -servername.
+run bash -lc "echo | openssl s_client -servername ${ROOT_DOMAIN} -connect ${ROOT_DOMAIN}:443 2>/dev/null | openssl x509 -noout -subject -issuer -dates -ext subjectAltName"
+
+# IP + reverse DNS (best-effort)
+IPV4_ROOT="$(dig +short "${ROOT_DOMAIN}" A | head -n1 || true)"
+if [[ -n "${IPV4_ROOT}" ]]; then
+  echo "${IPV4_ROOT}" > "${OUTDIR}/root_ipv4.txt"
+  run dig +noall +answer -x "${IPV4_ROOT}"
+fi
+
+log "\nWrote: ${OUTDIR}"
+log "Tip: compare 'server:' and other headers; 'Google Frontend' often implies a Google HTTPS LB/GFE edge."


### PR DESCRIPTION
Adds: \n- scripts/equa_cc_public_recon.sh: read-only DNS/headers/TLS probe to identify hosting surface without GCP auth\n- runbooks/EQUA_CC_COST_CHECK.md: quick billing-SKU checklist + common lingering charges\n\nSupports #358.